### PR TITLE
Implement multimult

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -87,6 +87,30 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -151,6 +175,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +261,28 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -232,10 +357,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -280,6 +420,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -335,6 +496,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,12 +524,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "p256k1"
 version = "0.1.0"
 dependencies = [
  "bindgen",
  "bitvec",
  "cc",
+ "criterion",
  "hex",
  "itertools",
  "libc",
@@ -387,6 +580,34 @@ checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
 dependencies = [
  "thiserror",
  "ucd-trie",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -429,6 +650,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +690,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -483,6 +732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +745,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -519,6 +780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +798,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+dependencies = [
+ "itoa 1.0.5",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -621,6 +903,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +986,70 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ syn = { version = "1.0.105", features = ["full"] }
 
 [dev-dependencies]
 libc = "0.2"
+criterion = "0.3"
+
+[[bench]]
+name = "point_bench"
+harness = false
 
 [lib]
 path = "src/lib.rs"    # The source file of the target.

--- a/benches/point_bench.rs
+++ b/benches/point_bench.rs
@@ -1,0 +1,31 @@
+use p256k1::{point::Point, scalar::Scalar};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand_core::OsRng;
+
+#[allow(non_snake_case)]
+pub fn bench_ecmult(c: &mut Criterion) {
+    let mut rng = OsRng::default();
+    let n = 2048usize;
+
+    let scalars: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
+    let points: Vec<Point> = (0..n)
+        .map(|_| Point::from(Scalar::random(&mut rng)))
+        .collect();
+
+    c.bench_function("point multimult", |b| {
+        b.iter(|| Point::multimult(scalars.clone(), points.clone()))
+    });
+
+    c.bench_function("point ecmult", |b| {
+        b.iter(|| {
+            let mut p = Point::identity();
+            for i in 0..n {
+                p += scalars[i] * points[i];
+            }
+        })
+    });
+}
+
+criterion_group!(benches, bench_ecmult);
+criterion_main!(benches);

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,7 @@ fn main() {
     base_config
         .file("secp256k1/src/secp256k1.c")
         .file("secp256k1/src/precomputed_ecmult.c")
+        .file("secp256k1/src/precomputed_ecmult_gen.c")
         .compile("libsecp256k1.a");
 
     // Tell cargo to invalidate the built crate whenever the wrapper changes

--- a/src/point.rs
+++ b/src/point.rs
@@ -66,7 +66,7 @@ pub struct Point {
 }
 
 #[no_mangle]
-pub extern "C" fn error_callback(
+extern "C" fn error_callback(
     text: *const ::std::os::raw::c_char,
     _data: *mut ::std::os::raw::c_void,
 ) {

--- a/src/point.rs
+++ b/src/point.rs
@@ -160,12 +160,12 @@ impl Point {
         }
     }
 
-    pub fn multimult(scalars: &Vec<Scalar>, points: &Vec<Point>) -> Result<Point, Error> {
+    pub fn multimult(scalars: Vec<Scalar>, points: Vec<Point>) -> Result<Point, Error> {
         let mut r = Point::new();
         let n = scalars.len() as u64;
         let mut sp = ScalarsPoints {
-            s: scalars.clone(),
-            p: points.clone(),
+            s: scalars,
+            p: points,
         };
         let sp_ptr: *mut c_void = &mut sp as *mut _ as *mut c_void;
         let error_callback_data = [0u8; 32];
@@ -589,10 +589,10 @@ mod tests {
         let xp = Point::from(x);
         let yp = Point::from(x);
 
-        let mut sv = [x, y].to_vec();
-        let mut pv = [xp, yp].to_vec();
+        let sv = [x, y].to_vec();
+        let pv = [xp, yp].to_vec();
 
-        let p = Point::multimult(&mut sv, &mut pv).unwrap();
+        let p = Point::multimult(sv, pv).unwrap();
 
         assert_eq!(p, x * xp + y * yp);
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -8,12 +8,13 @@ use core::{
     slice,
 };
 use num_traits::Zero;
+use std::os::raw::c_void;
 
 use crate::bindings::{
-    secp256k1_context, secp256k1_context_create, secp256k1_ecmult, secp256k1_fe,
+    secp256k1_callback, secp256k1_context, secp256k1_context_create, secp256k1_ecmult, secp256k1_ecmult_multi_callback, secp256k1_ecmult_multi_var, secp256k1_fe,
     secp256k1_fe_get_b32, secp256k1_fe_is_odd, secp256k1_fe_normalize_var, secp256k1_fe_set_b32,
     secp256k1_ge, secp256k1_ge_set_gej, secp256k1_ge_set_xo_var, secp256k1_gej,
-    secp256k1_gej_add_var, secp256k1_gej_neg, secp256k1_gej_set_ge, SECP256K1_CONTEXT_SIGN,
+    secp256k1_gej_add_var, secp256k1_gej_neg, secp256k1_gej_set_ge, secp256k1_scratch, SECP256K1_CONTEXT_SIGN,
     SECP256K1_TAG_PUBKEY_EVEN, SECP256K1_TAG_PUBKEY_ODD,
 };
 
@@ -105,8 +106,35 @@ impl Point {
             c
         }
     }
-}
+    /*
+    pub fn multimult(scalars: Vec<Scalar>, points: Vec<Point>) -> Point {
+        let mut r = Point::new();
+        let mut sp = (scalars, points);
+        let sp_ptr: *mut c_void = &mut sp as *mut _ as *mut c_void;
 
+        let null = std::ptr::null_mut::<secp256k1_fe>();
+        let error_callback = secp256k1_callback{
+            fn_: None,
+            data: null,
+        };
+
+        let zero = Scalar::zero();
+        let scratch_data = [0u8; 16384];
+        let scratch = secp256k1_scratch{
+            magic: [0u8; 8],
+            data: &mut scratch_data,
+            max_size: scratch_data.len() as u64,
+            alloc_size: scratch_data.len() as u64,
+        };
+
+        unsafe {
+            let i = secp256k1_ecmult_multi_var(&error_callback, &mut scratch, &mut r.gej, &zero.scalar, None, sp_ptr, scalars.len() as u64);
+        }
+        
+        r
+    }
+}
+*/
 impl Default for Point {
     fn default() -> Self {
         Point::identity()

--- a/src/point.rs
+++ b/src/point.rs
@@ -83,7 +83,7 @@ struct ScalarsPoints {
 }
 
 #[no_mangle]
-pub extern "C" fn ecmult_multi_callback(
+extern "C" fn ecmult_multi_callback(
     sc: *mut secp256k1_scalar,
     pt: *mut secp256k1_ge,
     idx: size_t,

--- a/src/point.rs
+++ b/src/point.rs
@@ -70,9 +70,11 @@ pub extern "C" fn error_callback(
     text: *const ::std::os::raw::c_char,
     _data: *mut ::std::os::raw::c_void,
 ) {
-    let c_str: &CStr = unsafe { CStr::from_ptr(text) };
-    let s: &str = c_str.to_str().unwrap();
-    println!("error_callback({})", s);
+    unsafe {
+        let c_str: &CStr = CStr::from_ptr(text);
+        let s: &str = c_str.to_str().unwrap();
+        println!("error_callback({s})");
+    }
 }
 
 struct ScalarsPoints {
@@ -87,7 +89,6 @@ pub extern "C" fn ecmult_multi_callback(
     idx: size_t,
     data: *mut ::std::os::raw::c_void,
 ) -> ::std::os::raw::c_int {
-    println!("ecmult_multi_callback({})", idx);
     unsafe {
         let sp: *mut ScalarsPoints = data as *mut ScalarsPoints;
 
@@ -195,7 +196,6 @@ impl Point {
                 return Err(Error::MultiMultFailed);
             }
         }
-        println!("leave unsafe");
 
         Ok(r)
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -17,8 +17,8 @@ use crate::bindings::{
     secp256k1_fe_get_b32, secp256k1_fe_is_odd, secp256k1_fe_normalize_var, secp256k1_fe_set_b32,
     secp256k1_ge, secp256k1_ge_set_gej, secp256k1_ge_set_xo_var, secp256k1_gej,
     secp256k1_gej_add_var, secp256k1_gej_neg, secp256k1_gej_set_ge, secp256k1_scalar,
-    secp256k1_scratch, size_t, SECP256K1_CONTEXT_SIGN, SECP256K1_TAG_PUBKEY_EVEN,
-    SECP256K1_TAG_PUBKEY_ODD,
+    secp256k1_scratch_space_create, secp256k1_scratch_space_destroy, size_t,
+    SECP256K1_CONTEXT_SIGN, SECP256K1_TAG_PUBKEY_EVEN, SECP256K1_TAG_PUBKEY_ODD,
 };
 
 use crate::scalar::Scalar;
@@ -176,27 +176,21 @@ impl Point {
         };
 
         let zero = Scalar::zero();
-        let mut scratch_data = [0u8; 16384];
-        let scratch_data_ptr: *mut c_void = &mut scratch_data as *mut _ as *mut c_void;
-        let mut scratch = secp256k1_scratch {
-            magic: [0u8; 8],
-            data: scratch_data_ptr,
-            max_size: scratch_data.len() as u64,
-            alloc_size: scratch_data.len() as u64,
-        };
-
+        let ctx = Point::ctx();
         let multi_callback: secp256k1_ecmult_multi_callback = Some(ecmult_multi_callback);
-        println!("enter unsafe");
+
         unsafe {
+            let scratch = secp256k1_scratch_space_create(ctx, 1048576);
             let i = secp256k1_ecmult_multi_var(
                 &multi_error_callback,
-                &mut scratch,
+                scratch,
                 &mut r.gej,
                 &zero.scalar,
                 multi_callback,
                 sp_ptr,
                 n,
             );
+            secp256k1_scratch_space_destroy(ctx, scratch);
             if i == 0 {
                 return Err(Error::MultiMultFailed);
             }

--- a/src/point.rs
+++ b/src/point.rs
@@ -582,18 +582,20 @@ mod tests {
     #[test]
     fn multimult() {
         let mut rng = OsRng::default();
+        let n = 1024usize;
 
-        let x = Scalar::random(&mut rng);
-        let y = Scalar::random(&mut rng);
+        let scalars: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
+        let points: Vec<Point> = (0..n)
+            .map(|_| Point::from(Scalar::random(&mut rng)))
+            .collect();
 
-        let xp = Point::from(x);
-        let yp = Point::from(x);
+        let mmp = Point::multimult(scalars.clone(), points.clone()).unwrap();
 
-        let sv = [x, y].to_vec();
-        let pv = [xp, yp].to_vec();
+        let mut ecp = Point::identity();
+        for i in 0..n {
+            ecp += scalars[i] * points[i];
+        }
 
-        let p = Point::multimult(sv, pv).unwrap();
-
-        assert_eq!(p, x * xp + y * yp);
+        assert_eq!(mmp, ecp);
     }
 }


### PR DESCRIPTION
This PR implements EC scalar/point multi multiplication using the well known Pippenger's algorithm.  This provides a significant speedup relative to sequential ecmult (roughly 3X faster depending on input size).

There is also a new unit test for multimult, and a criterion benchmark comparing multimult with a sequential ecmult.