### PR TITLE
Add to_bytes and from implementations for Signature underlying data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ num-traits = "0.2"
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10"
-thiserror = "1.0"
 
 [build-dependencies]
 bindgen = "0.53.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ num-traits = "0.2"
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10"
+thiserror = "1.0"
 
 [build-dependencies]
 bindgen = "0.53.1"

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -28,8 +28,6 @@ PubKey is a wrapper around libsecp256k1's secp256k1_pubkey struct.
 pub struct PubKey {
     /// The wrapped secp256k1_pubkey public key
     key: secp256k1_pubkey,
-    // The context associated with the public key
-    context: Context,
 }
 
 impl PubKey {
@@ -37,14 +35,10 @@ impl PubKey {
     pub fn new(sec_key: &Scalar) -> Result<Self, Error> {
         let mut pub_key = Self {
             key: secp256k1_pubkey { data: [0; 64] },
-            context: Context::default(),
         };
+        let ctx = Context::default();
         if unsafe {
-            secp256k1_ec_pubkey_create(
-                pub_key.context.context,
-                &mut pub_key.key,
-                sec_key.to_bytes().as_ptr(),
-            )
+            secp256k1_ec_pubkey_create(ctx.context, &mut pub_key.key, sec_key.to_bytes().as_ptr())
         } == 0
         {
             return Err(Error::InvalidSecretKey);

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -1,38 +1,50 @@
 use crate::bindings::{
     secp256k1_ec_pubkey_create, secp256k1_ecdsa_sign, secp256k1_ecdsa_signature,
+    secp256k1_ecdsa_signature_parse_compact, secp256k1_ecdsa_signature_serialize_compact,
     secp256k1_ecdsa_verify, secp256k1_pubkey,
 };
 use crate::context::Context;
 use crate::scalar::Scalar;
 use std::array::TryFromSliceError;
-use thiserror::Error as ThisError;
 
-#[derive(ThisError, Debug)]
+#[derive(Debug)]
 /// Errors in ECDSA signature operations
 pub enum Error {
     /// Error occurred due to invalid secret key
-    #[error("Invalid Secret Key")]
     InvalidSecretKey,
     /// Error occurred during a try from operation
-    #[error("TryFrom operation failed: {0}")]
-    TryFrom(#[from] TryFromSliceError),
+    TryFrom(String),
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(e: TryFromSliceError) -> Self {
+        Error::TryFrom(e.to_string())
+    }
 }
 
 /**
 PubKey is a wrapper around libsecp256k1's secp256k1_pubkey struct.
 */
 pub struct PubKey {
+    /// The wrapped secp256k1_pubkey public key
     key: secp256k1_pubkey,
+    /// The context associated with the public key
+    context: Context,
 }
 
 impl PubKey {
     /// Construct a public key from a given secret key
-    pub fn new(ctx: &Context, sec_key: &Scalar) -> Result<Self, Error> {
+    pub fn new(sec_key: &Scalar) -> Result<Self, Error> {
         let mut pub_key = Self {
             key: secp256k1_pubkey { data: [0; 64] },
+            context: Context::default(),
         };
         if unsafe {
-            secp256k1_ec_pubkey_create(ctx.context, &mut pub_key.key, sec_key.to_bytes().as_ptr())
+            secp256k1_ec_pubkey_create(
+                pub_key.context.context,
+                &mut pub_key.key,
+                sec_key.to_bytes().as_ptr(),
+            )
         } == 0
         {
             return Err(Error::InvalidSecretKey);
@@ -47,17 +59,20 @@ Signature is a wrapper around libsecp256k1's secp256k1_ecdsa_signature struct.
 pub struct Signature {
     /// The wrapped libsecp256k1 signature
     pub signature: secp256k1_ecdsa_signature,
+    /// The context associated with the given signature
+    pub context: Context,
 }
 
 impl Signature {
     /// Construct an ECDSA signature
-    pub fn new(ctx: &Context, hash: &[u8], sec_key: &Scalar) -> Result<Self, Error> {
+    pub fn new(hash: &[u8], sec_key: &Scalar) -> Result<Self, Error> {
         let mut sig = Self {
             signature: secp256k1_ecdsa_signature { data: [0; 64] },
+            context: Context::default(),
         };
         if unsafe {
             secp256k1_ecdsa_sign(
-                ctx.context,
+                sig.context.context,
                 &mut sig.signature,
                 hash.as_ptr(),
                 sec_key.to_bytes().as_ptr(),
@@ -72,33 +87,65 @@ impl Signature {
     }
 
     /// Verify an ECDSA signature
-    pub fn verify(&self, ctx: &Context, hash: &[u8], pub_key: &PubKey) -> bool {
+    pub fn verify(&self, hash: &[u8], pub_key: &PubKey) -> bool {
         1 == unsafe {
-            secp256k1_ecdsa_verify(ctx.context, &self.signature, hash.as_ptr(), &pub_key.key)
+            secp256k1_ecdsa_verify(
+                self.context.context,
+                &self.signature,
+                hash.as_ptr(),
+                &pub_key.key,
+            )
         }
     }
 
-    /// Return the underlying bytes within a signature
+    /// Returns the signature's deserialized underlying data
     pub fn to_bytes(&self) -> [u8; 64] {
-        self.signature.data
+        let mut bytes = [0u8; 64];
+        //Deserialize the signature's data
+        unsafe {
+            secp256k1_ecdsa_signature_serialize_compact(
+                self.context.context,
+                bytes.as_mut_ptr(),
+                &self.signature,
+            );
+        }
+        bytes
     }
 }
 
-impl From<[u8; 64]> for Signature {
-    /// Create a signature given an array of signed data.
-    fn from(data: [u8; 64]) -> Self {
-        Self {
-            signature: secp256k1_ecdsa_signature { data },
+impl TryFrom<[u8; 64]> for Signature {
+    type Error = Error;
+    /// Create an ECDSA signature given an array of signed data.
+    /// Note it also serializes the data in compact (64 byte) format
+    fn try_from(data: [u8; 64]) -> Result<Self, Self::Error> {
+        let mut sig = Self {
+            signature: secp256k1_ecdsa_signature { data: [0u8; 64] },
+            context: Context::default(),
+        };
+        //Attempt to serialize the data into the signature
+        let parsed = unsafe {
+            secp256k1_ecdsa_signature_parse_compact(
+                sig.context.context,
+                &mut sig.signature,
+                data.as_ptr(),
+            )
+        };
+        if parsed == 0 {
+            return Err(Error::TryFrom(format!(
+                "Failed to serialize input data into compact (64 byte) form."
+            )));
         }
+        Ok(sig)
     }
 }
 
 impl TryFrom<&[u8]> for Signature {
     type Error = Error;
-    /// Create a signature given a slice of signed data.
+    /// Create an ECDSA signature given a slice of signed data.
+    /// Note it also serializes the data in compact (64 byte) format
     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
         let data: [u8; 64] = data[0..].try_into()?;
-        Ok(Signature::from(data))
+        Ok(Signature::try_from(data)?)
     }
 }
 
@@ -110,12 +157,10 @@ mod tests {
 
     #[test]
     fn signature_generation() {
-        let ctx = Context::default();
-
         // Generate a secret and public key
         let mut rnd = OsRng::default();
         let sec_key = Scalar::random(&mut rnd);
-        let pub_key = PubKey::new(&ctx, &sec_key).unwrap();
+        let pub_key = PubKey::new(&sec_key).unwrap();
 
         // Instead of signing a message directly, must sign a 32-byte hash of it.
         let msg = b"Hello, world!";
@@ -123,10 +168,10 @@ mod tests {
         hasher.update(msg);
         let msg_hash = hasher.finalize();
         // Generate a ECDSA signature
-        let sig = Signature::new(&ctx, &msg_hash, &sec_key).unwrap();
+        let sig = Signature::new(&msg_hash, &sec_key).unwrap();
 
         // Verify the generated signature is valid using the msg_hash and corresponding public key
-        assert!(sig.verify(&ctx, &msg_hash, &pub_key));
+        assert!(sig.verify(&msg_hash, &pub_key));
     }
 
     #[test]
@@ -138,12 +183,14 @@ mod tests {
 
         let sig_from_struct = Signature {
             signature: secp256k1_ecdsa_signature { data: bytes },
+            context: Context::default(),
         };
         let sig_from_slice = Signature::try_from(bytes.as_slice()).unwrap();
-        let sig_from_array = Signature::from(bytes);
+        let sig_from_array = Signature::try_from(bytes).unwrap();
 
-        assert_eq!(sig_from_struct.to_bytes(), sig_from_slice.to_bytes());
-        assert_eq!(sig_from_struct.to_bytes(), sig_from_array.to_bytes());
+        assert_ne!(sig_from_struct.to_bytes(), sig_from_slice.to_bytes());
+        assert_ne!(sig_from_struct.to_bytes(), sig_from_array.to_bytes());
+        assert_eq!(sig_from_array.to_bytes(), sig_from_slice.to_bytes());
 
         let mut too_small = [0u8; 63];
         rng.fill_bytes(&mut too_small);
@@ -155,12 +202,13 @@ mod tests {
     }
 
     #[test]
-    fn to_bytes() {
+    fn serialize_deserialize() {
         let mut rng = OsRng::default();
         let mut bytes = [0u8; 64];
         rng.fill_bytes(&mut bytes);
 
-        let sig = Signature::from(bytes);
-        assert_eq!(sig.to_bytes(), sig.signature.data);
+        //Serialize with try_from and deserialize with to_bytes
+        let sig = Signature::try_from(bytes).unwrap();
+        assert_eq!(sig.to_bytes(), bytes);
     }
 }

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -85,6 +85,7 @@ impl Signature {
 }
 
 impl From<[u8; 64]> for Signature {
+    /// Create a signature given an array of signed data.
     fn from(data: [u8; 64]) -> Self {
         Self {
             signature: secp256k1_ecdsa_signature { data },
@@ -94,6 +95,7 @@ impl From<[u8; 64]> for Signature {
 
 impl TryFrom<&[u8]> for Signature {
     type Error = Error;
+    /// Create a signature given a slice of signed data.
     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
         let data: [u8; 64] = data[0..].try_into()?;
         Ok(Signature::from(data))

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -125,9 +125,9 @@ impl TryFrom<(&Context, [u8; 64])> for Signature {
             )
         };
         if parsed == 0 {
-            return Err(Error::TryFrom(format!(
-                "Failed to serialize input data into compact (64 byte) form."
-            )));
+            return Err(Error::TryFrom(
+                "Failed to serialize input data into compact (64 byte) form.".to_string(),
+            ));
         }
         Ok(sig)
     }

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -28,16 +28,23 @@ PubKey is a wrapper around libsecp256k1's secp256k1_pubkey struct.
 pub struct PubKey {
     /// The wrapped secp256k1_pubkey public key
     key: secp256k1_pubkey,
+    // The context associated with the public key
+    context: Context,
 }
 
 impl PubKey {
     /// Construct a public key from a given secret key
-    pub fn new(ctx: &Context, sec_key: &Scalar) -> Result<Self, Error> {
+    pub fn new(sec_key: &Scalar) -> Result<Self, Error> {
         let mut pub_key = Self {
             key: secp256k1_pubkey { data: [0; 64] },
+            context: Context::default(),
         };
         if unsafe {
-            secp256k1_ec_pubkey_create(ctx.context, &mut pub_key.key, sec_key.to_bytes().as_ptr())
+            secp256k1_ec_pubkey_create(
+                pub_key.context.context,
+                &mut pub_key.key,
+                sec_key.to_bytes().as_ptr(),
+            )
         } == 0
         {
             return Err(Error::InvalidSecretKey);
@@ -52,17 +59,20 @@ Signature is a wrapper around libsecp256k1's secp256k1_ecdsa_signature struct.
 pub struct Signature {
     /// The wrapped libsecp256k1 signature
     pub signature: secp256k1_ecdsa_signature,
+    /// The context associated with the signature
+    pub context: Context,
 }
 
 impl Signature {
     /// Construct an ECDSA signature
-    pub fn new(ctx: &Context, hash: &[u8], sec_key: &Scalar) -> Result<Self, Error> {
+    pub fn new(hash: &[u8], sec_key: &Scalar) -> Result<Self, Error> {
         let mut sig = Self {
             signature: secp256k1_ecdsa_signature { data: [0; 64] },
+            context: Context::default(),
         };
         if unsafe {
             secp256k1_ecdsa_sign(
-                ctx.context,
+                sig.context.context,
                 &mut sig.signature,
                 hash.as_ptr(),
                 sec_key.to_bytes().as_ptr(),
@@ -77,19 +87,24 @@ impl Signature {
     }
 
     /// Verify an ECDSA signature
-    pub fn verify(&self, ctx: &Context, hash: &[u8], pub_key: &PubKey) -> bool {
+    pub fn verify(&self, hash: &[u8], pub_key: &PubKey) -> bool {
         1 == unsafe {
-            secp256k1_ecdsa_verify(ctx.context, &self.signature, hash.as_ptr(), &pub_key.key)
+            secp256k1_ecdsa_verify(
+                self.context.context,
+                &self.signature,
+                hash.as_ptr(),
+                &pub_key.key,
+            )
         }
     }
 
     /// Returns the signature's deserialized underlying data
-    pub fn to_bytes(&self, ctx: &Context) -> [u8; 64] {
+    pub fn to_bytes(&self) -> [u8; 64] {
         let mut bytes = [0u8; 64];
         //Deserialize the signature's data
         unsafe {
             secp256k1_ecdsa_signature_serialize_compact(
-                ctx.context,
+                self.context.context,
                 bytes.as_mut_ptr(),
                 &self.signature,
             );
@@ -98,30 +113,31 @@ impl Signature {
     }
 }
 
-impl TryFrom<(&Context, &[u8])> for Signature {
+impl TryFrom<&[u8]> for Signature {
     type Error = Error;
     /// Create an ECDSA signature given a slice of signed data.
     /// Note it also serializes the data in compact (64 byte) format
-    fn try_from(input: (&Context, &[u8])) -> Result<Self, Self::Error> {
-        let data: [u8; 64] = input.1[0..].try_into()?;
-        Signature::try_from((input.0, data))
+    fn try_from(input: &[u8]) -> Result<Self, Self::Error> {
+        let data: [u8; 64] = input[0..].try_into()?;
+        Signature::try_from(data)
     }
 }
 
-impl TryFrom<(&Context, [u8; 64])> for Signature {
+impl TryFrom<[u8; 64]> for Signature {
     type Error = Error;
     /// Create an ECDSA signature given an array of signed data.
     /// Note it also serializes the data in compact (64 byte) format
-    fn try_from(input: (&Context, [u8; 64])) -> Result<Self, Self::Error> {
+    fn try_from(input: [u8; 64]) -> Result<Self, Self::Error> {
         let mut sig = Self {
             signature: secp256k1_ecdsa_signature { data: [0u8; 64] },
+            context: Context::default(),
         };
         //Attempt to serialize the data into the signature
         let parsed = unsafe {
             secp256k1_ecdsa_signature_parse_compact(
-                input.0.context,
+                sig.context.context,
                 &mut sig.signature,
-                input.1.as_ptr(),
+                input.as_ptr(),
             )
         };
         if parsed == 0 {
@@ -141,13 +157,10 @@ mod tests {
 
     #[test]
     fn signature_generation() {
-        //Create a context
-        let ctx = Context::default();
-
         // Generate a secret and public key
         let mut rnd = OsRng::default();
         let sec_key = Scalar::random(&mut rnd);
-        let pub_key = PubKey::new(&ctx, &sec_key).unwrap();
+        let pub_key = PubKey::new(&sec_key).unwrap();
 
         // Instead of signing a message directly, must sign a 32-byte hash of it.
         let msg = b"Hello, world!";
@@ -155,17 +168,14 @@ mod tests {
         hasher.update(msg);
         let msg_hash = hasher.finalize();
         // Generate a ECDSA signature
-        let sig = Signature::new(&ctx, &msg_hash, &sec_key).unwrap();
+        let sig = Signature::new(&msg_hash, &sec_key).unwrap();
 
         // Verify the generated signature is valid using the msg_hash and corresponding public key
-        assert!(sig.verify(&ctx, &msg_hash, &pub_key));
+        assert!(sig.verify(&msg_hash, &pub_key));
     }
 
     #[test]
     fn from() {
-        //Create a context
-        let ctx = Context::default();
-
         // Create random data bytes to serialize
         let mut rng = OsRng::default();
         let mut bytes = [0u8; 64];
@@ -173,42 +183,34 @@ mod tests {
 
         let sig_from_struct = Signature {
             signature: secp256k1_ecdsa_signature { data: bytes },
+            context: Context::default(),
         };
-        let sig_from_slice = Signature::try_from((&ctx, bytes.as_slice())).unwrap();
-        let sig_from_array = Signature::try_from((&ctx, bytes)).unwrap();
+        let sig_from_slice = Signature::try_from(bytes.as_slice()).unwrap();
+        let sig_from_array = Signature::try_from(bytes).unwrap();
 
-        assert_ne!(
-            sig_from_struct.to_bytes(&ctx),
-            sig_from_slice.to_bytes(&ctx)
-        );
-        assert_ne!(
-            sig_from_struct.to_bytes(&ctx),
-            sig_from_array.to_bytes(&ctx)
-        );
-        assert_eq!(sig_from_array.to_bytes(&ctx), sig_from_slice.to_bytes(&ctx));
+        assert_ne!(sig_from_struct.to_bytes(), sig_from_slice.to_bytes());
+        assert_ne!(sig_from_struct.to_bytes(), sig_from_array.to_bytes());
+        assert_eq!(sig_from_array.to_bytes(), sig_from_slice.to_bytes());
 
         let mut too_small = [0u8; 63];
         rng.fill_bytes(&mut too_small);
-        assert!(Signature::try_from((&ctx, too_small.as_slice())).is_err());
+        assert!(Signature::try_from(too_small.as_slice()).is_err());
 
         let mut too_big = [0u8; 65];
         rng.fill_bytes(&mut too_big);
-        assert!(Signature::try_from((&ctx, too_big.as_slice())).is_err());
+        assert!(Signature::try_from(too_big.as_slice()).is_err());
     }
 
     #[test]
     fn serialize_deserialize() {
-        //Create a context
-        let ctx = Context::default();
-
         // Generate random data bytes
         let mut rng = OsRng::default();
         let mut bytes = [0u8; 64];
         rng.fill_bytes(&mut bytes);
 
         //Serialize with try_from and deserialize with to_bytes
-        let sig = Signature::try_from((&ctx, bytes)).unwrap();
+        let sig = Signature::try_from(bytes).unwrap();
         assert_ne!(sig.signature.data, bytes);
-        assert_eq!(sig.to_bytes(&ctx), bytes);
+        assert_eq!(sig.to_bytes(), bytes);
     }
 }

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -28,23 +28,16 @@ PubKey is a wrapper around libsecp256k1's secp256k1_pubkey struct.
 pub struct PubKey {
     /// The wrapped secp256k1_pubkey public key
     key: secp256k1_pubkey,
-    /// The context associated with the public key
-    context: Context,
 }
 
 impl PubKey {
     /// Construct a public key from a given secret key
-    pub fn new(sec_key: &Scalar) -> Result<Self, Error> {
+    pub fn new(ctx: &Context, sec_key: &Scalar) -> Result<Self, Error> {
         let mut pub_key = Self {
             key: secp256k1_pubkey { data: [0; 64] },
-            context: Context::default(),
         };
         if unsafe {
-            secp256k1_ec_pubkey_create(
-                pub_key.context.context,
-                &mut pub_key.key,
-                sec_key.to_bytes().as_ptr(),
-            )
+            secp256k1_ec_pubkey_create(ctx.context, &mut pub_key.key, sec_key.to_bytes().as_ptr())
         } == 0
         {
             return Err(Error::InvalidSecretKey);
@@ -59,20 +52,17 @@ Signature is a wrapper around libsecp256k1's secp256k1_ecdsa_signature struct.
 pub struct Signature {
     /// The wrapped libsecp256k1 signature
     pub signature: secp256k1_ecdsa_signature,
-    /// The context associated with the given signature
-    pub context: Context,
 }
 
 impl Signature {
     /// Construct an ECDSA signature
-    pub fn new(hash: &[u8], sec_key: &Scalar) -> Result<Self, Error> {
+    pub fn new(ctx: &Context, hash: &[u8], sec_key: &Scalar) -> Result<Self, Error> {
         let mut sig = Self {
             signature: secp256k1_ecdsa_signature { data: [0; 64] },
-            context: Context::default(),
         };
         if unsafe {
             secp256k1_ecdsa_sign(
-                sig.context.context,
+                ctx.context,
                 &mut sig.signature,
                 hash.as_ptr(),
                 sec_key.to_bytes().as_ptr(),
@@ -86,49 +76,22 @@ impl Signature {
         Ok(sig)
     }
 
-    /// Verify an ECDSA signature
-    pub fn verify(&self, hash: &[u8], pub_key: &PubKey) -> bool {
-        1 == unsafe {
-            secp256k1_ecdsa_verify(
-                self.context.context,
-                &self.signature,
-                hash.as_ptr(),
-                &pub_key.key,
-            )
-        }
+    /// Create an ECDSA signature given a slice of signed data.
+    /// Note it also serializes the data in compact (64 byte) format
+    pub fn try_from_slice(ctx: &Context, data: &[u8]) -> Result<Self, Error> {
+        let data: [u8; 64] = data[0..].try_into()?;
+        Signature::try_from_array(ctx, data)
     }
 
-    /// Returns the signature's deserialized underlying data
-    pub fn to_bytes(&self) -> [u8; 64] {
-        let mut bytes = [0u8; 64];
-        //Deserialize the signature's data
-        unsafe {
-            secp256k1_ecdsa_signature_serialize_compact(
-                self.context.context,
-                bytes.as_mut_ptr(),
-                &self.signature,
-            );
-        }
-        bytes
-    }
-}
-
-impl TryFrom<[u8; 64]> for Signature {
-    type Error = Error;
     /// Create an ECDSA signature given an array of signed data.
     /// Note it also serializes the data in compact (64 byte) format
-    fn try_from(data: [u8; 64]) -> Result<Self, Self::Error> {
+    pub fn try_from_array(ctx: &Context, data: [u8; 64]) -> Result<Self, Error> {
         let mut sig = Self {
             signature: secp256k1_ecdsa_signature { data: [0u8; 64] },
-            context: Context::default(),
         };
         //Attempt to serialize the data into the signature
         let parsed = unsafe {
-            secp256k1_ecdsa_signature_parse_compact(
-                sig.context.context,
-                &mut sig.signature,
-                data.as_ptr(),
-            )
+            secp256k1_ecdsa_signature_parse_compact(ctx.context, &mut sig.signature, data.as_ptr())
         };
         if parsed == 0 {
             return Err(Error::TryFrom(format!(
@@ -137,15 +100,26 @@ impl TryFrom<[u8; 64]> for Signature {
         }
         Ok(sig)
     }
-}
 
-impl TryFrom<&[u8]> for Signature {
-    type Error = Error;
-    /// Create an ECDSA signature given a slice of signed data.
-    /// Note it also serializes the data in compact (64 byte) format
-    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-        let data: [u8; 64] = data[0..].try_into()?;
-        Ok(Signature::try_from(data)?)
+    /// Verify an ECDSA signature
+    pub fn verify(&self, ctx: &Context, hash: &[u8], pub_key: &PubKey) -> bool {
+        1 == unsafe {
+            secp256k1_ecdsa_verify(ctx.context, &self.signature, hash.as_ptr(), &pub_key.key)
+        }
+    }
+
+    /// Returns the signature's deserialized underlying data
+    pub fn to_bytes(&self, ctx: &Context) -> [u8; 64] {
+        let mut bytes = [0u8; 64];
+        //Deserialize the signature's data
+        unsafe {
+            secp256k1_ecdsa_signature_serialize_compact(
+                ctx.context,
+                bytes.as_mut_ptr(),
+                &self.signature,
+            );
+        }
+        bytes
     }
 }
 
@@ -157,10 +131,13 @@ mod tests {
 
     #[test]
     fn signature_generation() {
+        //Create a context
+        let ctx = Context::default();
+
         // Generate a secret and public key
         let mut rnd = OsRng::default();
         let sec_key = Scalar::random(&mut rnd);
-        let pub_key = PubKey::new(&sec_key).unwrap();
+        let pub_key = PubKey::new(&ctx, &sec_key).unwrap();
 
         // Instead of signing a message directly, must sign a 32-byte hash of it.
         let msg = b"Hello, world!";
@@ -168,47 +145,59 @@ mod tests {
         hasher.update(msg);
         let msg_hash = hasher.finalize();
         // Generate a ECDSA signature
-        let sig = Signature::new(&msg_hash, &sec_key).unwrap();
+        let sig = Signature::new(&ctx, &msg_hash, &sec_key).unwrap();
 
         // Verify the generated signature is valid using the msg_hash and corresponding public key
-        assert!(sig.verify(&msg_hash, &pub_key));
+        assert!(sig.verify(&ctx, &msg_hash, &pub_key));
     }
 
     #[test]
     fn from() {
+        //Create a context
+        let ctx = Context::default();
+
+        // Create random data bytes to serialize
         let mut rng = OsRng::default();
         let mut bytes = [0u8; 64];
-
         rng.fill_bytes(&mut bytes);
 
         let sig_from_struct = Signature {
             signature: secp256k1_ecdsa_signature { data: bytes },
-            context: Context::default(),
         };
-        let sig_from_slice = Signature::try_from(bytes.as_slice()).unwrap();
-        let sig_from_array = Signature::try_from(bytes).unwrap();
+        let sig_from_slice = Signature::try_from_slice(&ctx, bytes.as_slice()).unwrap();
+        let sig_from_array = Signature::try_from_array(&ctx, bytes).unwrap();
 
-        assert_ne!(sig_from_struct.to_bytes(), sig_from_slice.to_bytes());
-        assert_ne!(sig_from_struct.to_bytes(), sig_from_array.to_bytes());
-        assert_eq!(sig_from_array.to_bytes(), sig_from_slice.to_bytes());
+        assert_ne!(
+            sig_from_struct.to_bytes(&ctx),
+            sig_from_slice.to_bytes(&ctx)
+        );
+        assert_ne!(
+            sig_from_struct.to_bytes(&ctx),
+            sig_from_array.to_bytes(&ctx)
+        );
+        assert_eq!(sig_from_array.to_bytes(&ctx), sig_from_slice.to_bytes(&ctx));
 
         let mut too_small = [0u8; 63];
         rng.fill_bytes(&mut too_small);
-        assert!(Signature::try_from(too_small.as_slice()).is_err());
+        assert!(Signature::try_from_slice(&ctx, too_small.as_slice()).is_err());
 
         let mut too_big = [0u8; 65];
         rng.fill_bytes(&mut too_big);
-        assert!(Signature::try_from(too_big.as_slice()).is_err());
+        assert!(Signature::try_from_slice(&ctx, too_big.as_slice()).is_err());
     }
 
     #[test]
     fn serialize_deserialize() {
+        //Create a context
+        let ctx = Context::default();
+
+        // Generate random data bytes
         let mut rng = OsRng::default();
         let mut bytes = [0u8; 64];
         rng.fill_bytes(&mut bytes);
 
-        //Serialize with try_from and deserialize with to_bytes
-        let sig = Signature::try_from(bytes).unwrap();
-        assert_eq!(sig.to_bytes(), bytes);
+        //Serialize with try_from_array and deserialize with to_bytes
+        let sig = Signature::try_from_array(&ctx, bytes).unwrap();
+        assert_eq!(sig.to_bytes(&ctx), bytes);
     }
 }


### PR DESCRIPTION
I assumed that TryFrom should fail also when more data than expected is given. I.e. it will only except exactly 64 bytes.