### PR TITLE
add derive clone to ecdsa::PublicKey

### DIFF
--- a/p256k1/src/ecdsa.rs
+++ b/p256k1/src/ecdsa.rs
@@ -39,6 +39,7 @@ impl From<TryFromSliceError> for Error {
 /**
 PublicKey is a wrapper around libsecp256k1's secp256k1_pubkey struct.
 */
+#[derive(Clone, Copy)]
 pub struct PublicKey {
     /// The wrapped secp256k1_pubkey public key
     key: secp256k1_pubkey,


### PR DESCRIPTION
Was wanting to add this to make my life easier in frost-signer/coordinator, but I can work around if you don't want this to be cloneable.