### PR TITLE
Switch to bs58

### DIFF
--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256k1"
-version = "4.0.1"
+version = "4.1.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["api-bindings", "cryptography", "mathematics"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base58 = "0.2"
 bitvec = "1.0.1"
+bs58 = "0.4.0"
 hex = "0.4"
 num-traits = "0.2"
 primitive-types = "0.12"

--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "cryptography", "mathematics"]
 
 [dependencies]
 bitvec = "1.0.1"
-bs58 = "0.4.0"
+bs58 = "0.4"
 hex = "0.4"
 num-traits = "0.2"
 primitive-types = "0.12"

--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256k1"
-version = "4.1.0"
+version = "5.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/p256k1/src/ecdsa.rs
+++ b/p256k1/src/ecdsa.rs
@@ -1,4 +1,4 @@
-use bs58::{self, decode::Error as DecodeError};
+use bs58;
 use std::array::TryFromSliceError;
 
 use crate::_rename::{
@@ -8,24 +8,8 @@ use crate::_rename::{
 };
 use crate::bindings::{secp256k1_ecdsa_signature, secp256k1_pubkey, SECP256K1_EC_COMPRESSED};
 use crate::context::Context;
+use crate::errors::{Base58Error, ConversionError};
 use crate::scalar::Scalar;
-
-/// Re-export of crate `bs58`'s decode error
-pub type Base58DecodeError = DecodeError;
-
-#[derive(Debug, Clone)]
-/// Base58-related errors
-pub enum Base58Error {
-    /// Error decoding
-    Decode(Base58DecodeError),
-}
-
-/// Errors when converting scalars
-#[derive(Debug, Clone)]
-pub enum ConversionError {
-    /// Error converting a base58 string to bytes
-    Base58(Base58Error),
-}
 
 #[derive(Debug, Clone)]
 /// Errors in ECDSA signature operations

--- a/p256k1/src/errors.rs
+++ b/p256k1/src/errors.rs
@@ -1,0 +1,28 @@
+use bs58::{decode::Error as DecodeError, encode::Error as EncodeError};
+
+/// Re-export of crate `bs58`'s decode error
+pub type Base58DecodeError = DecodeError;
+/// Re-export of crate `bs58`'s encode error
+pub type Base58EncodeError = EncodeError;
+
+#[derive(Debug, Clone)]
+/// Base58-related errors
+pub enum Base58Error {
+    /// Error decoding
+    Decode(Base58DecodeError),
+    /// Error encoding
+    Encode(Base58EncodeError),
+}
+
+#[derive(Debug, Clone)]
+/// Errors when converting points
+pub enum ConversionError {
+    /// Error decompressing a point into a field element
+    BadFieldElement,
+    /// Error decompressing a point into a group element
+    BadGroupElement,
+    /// Error converting a byte slice into Compressed
+    WrongNumberOfBytes(usize),
+    /// Error converting a base58 string to bytes
+    Base58(Base58Error),
+}

--- a/p256k1/src/field.rs
+++ b/p256k1/src/field.rs
@@ -1,5 +1,5 @@
 use bitvec::prelude::*;
-use bs58::{self, decode::Error as DecodeError, encode::Error as EncodeError};
+use bs58;
 use core::{
     cmp::{Eq, PartialEq},
     convert::{From, TryFrom},
@@ -17,6 +17,8 @@ use crate::_rename::{
 };
 use crate::bindings::secp256k1_fe;
 
+use crate::errors::{Base58Error, ConversionError};
+
 use crate::scalar::Scalar;
 
 /// Field size
@@ -24,29 +26,6 @@ pub const P: [u8; 32] = [
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xFF, 0xFF, 0xFC, 0x2F,
 ];
-
-/// Re-export of crate `bs58`'s decode error
-pub type Base58DecodeError = DecodeError;
-/// Re-export of crate `bs58`'s encode error
-pub type Base58EncodeError = EncodeError;
-
-#[derive(Debug, Clone)]
-/// Base58-related errors
-pub enum Base58Error {
-    /// Error decoding
-    Decode(Base58DecodeError),
-    /// Error encoding
-    Encode(Base58EncodeError),
-}
-
-#[derive(Debug, Clone)]
-/// Errors when converting field elements
-pub enum ConversionError {
-    /// Error converting a byte slice into element
-    WrongNumberOfBytes(usize),
-    /// Error converting a base58 string to bytes
-    Base58(Base58Error),
-}
 
 #[derive(Debug, Clone)]
 /// Errors in field element operations

--- a/p256k1/src/field.rs
+++ b/p256k1/src/field.rs
@@ -1,5 +1,5 @@
-use base58::{FromBase58, ToBase58};
 use bitvec::prelude::*;
+use bs58::{self, decode::Error as DecodeError, encode::Error as EncodeError};
 use core::{
     cmp::{Eq, PartialEq},
     convert::{From, TryFrom},
@@ -25,13 +25,27 @@ pub const P: [u8; 32] = [
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xFF, 0xFF, 0xFC, 0x2F,
 ];
 
+/// Re-export of crate `bs58`'s decode error
+pub type Base58DecodeError = DecodeError;
+/// Re-export of crate `bs58`'s encode error
+pub type Base58EncodeError = EncodeError;
+
+#[derive(Debug, Clone)]
+/// Base58-related errors
+pub enum Base58Error {
+    /// Error decoding
+    Decode(Base58DecodeError),
+    /// Error encoding
+    Encode(Base58EncodeError),
+}
+
 #[derive(Debug, Clone)]
 /// Errors when converting field elements
 pub enum ConversionError {
     /// Error converting a byte slice into element
     WrongNumberOfBytes(usize),
     /// Error converting a base58 string to bytes
-    Base58(String),
+    Base58(Base58Error),
 }
 
 #[derive(Debug, Clone)]
@@ -155,7 +169,7 @@ impl Default for Element {
 
 impl Display for Element {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}", self.to_bytes().to_base58())
+        write!(f, "{}", bs58::encode(self.to_bytes()).into_string())
     }
 }
 
@@ -221,19 +235,18 @@ impl TryFrom<&[u8]> for Element {
 impl TryFrom<&str> for Element {
     type Error = Error;
     fn try_from(s: &str) -> Result<Self, Error> {
-        match s.from_base58() {
+        match bs58::decode(s).into_vec() {
             Ok(bytes) => Element::try_from(&bytes[..]),
-            Err(e) => Err(Error::Conversion(ConversionError::Base58(format!(
-                "{:?}",
-                e
-            )))),
+            Err(e) => Err(Error::Conversion(ConversionError::Base58(
+                Base58Error::Decode(e),
+            ))),
         }
     }
 }
 
 impl From<Element> for String {
     fn from(s: Element) -> String {
-        s.to_bytes().to_base58()
+        bs58::encode(s.to_bytes()).into_string()
     }
 }
 

--- a/p256k1/src/lib.rs
+++ b/p256k1/src/lib.rs
@@ -20,6 +20,9 @@ pub mod context;
 /// ECDSA operations
 pub mod ecdsa;
 
+/// Errors
+pub mod errors;
+
 /// Point operations on the secp256k1 curve
 pub mod point;
 

--- a/p256k1/src/point.rs
+++ b/p256k1/src/point.rs
@@ -1,4 +1,4 @@
-use bs58::{self, decode::Error as DecodeError, encode::Error as EncodeError};
+use bs58;
 use core::{
     cmp::{Eq, PartialEq},
     convert::{From, TryFrom},
@@ -18,6 +18,7 @@ use crate::{
         secp256k1_callback, secp256k1_ecmult_multi_callback, secp256k1_fe, secp256k1_ge,
         secp256k1_gej, secp256k1_scalar, SECP256K1_TAG_PUBKEY_EVEN, SECP256K1_TAG_PUBKEY_ODD,
     },
+    errors::{Base58Error, ConversionError},
     group::secp256k1_ge_set_gej,
 };
 
@@ -61,33 +62,6 @@ pub const N: [u8; 32] = [
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
     0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x41,
 ];
-
-/// Re-export of crate `bs58`'s decode error
-pub type Base58DecodeError = DecodeError;
-/// Re-export of crate `bs58`'s encode error
-pub type Base58EncodeError = EncodeError;
-
-#[derive(Debug, Clone)]
-/// Base58-related errors
-pub enum Base58Error {
-    /// Error decoding
-    Decode(Base58DecodeError),
-    /// Error encoding
-    Encode(Base58EncodeError),
-}
-
-#[derive(Debug, Clone)]
-/// Errors when converting points
-pub enum ConversionError {
-    /// Error decompressing a point into a field element
-    BadFieldElement,
-    /// Error decompressing a point into a group element
-    BadGroupElement,
-    /// Error converting a byte slice into Compressed
-    WrongNumberOfBytes(usize),
-    /// Error converting a base58 string to bytes
-    Base58(Base58Error),
-}
 
 #[derive(Debug, Clone)]
 /// Errors in point operations

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -1,5 +1,5 @@
 use bitvec::prelude::*;
-use bs58::{self, decode::Error as DecodeError, encode::Error as EncodeError};
+use bs58;
 use core::{
     cmp::{Eq, PartialEq},
     convert::{From, TryFrom},
@@ -19,28 +19,7 @@ use crate::bindings::secp256k1_scalar;
 
 use crate::point::Point;
 
-/// Re-export of crate `bs58`'s decode error
-pub type Base58DecodeError = DecodeError;
-/// Re-export of crate `bs58`'s encode error
-pub type Base58EncodeError = EncodeError;
-
-#[derive(Debug, Clone)]
-/// Base58-related errors
-pub enum Base58Error {
-    /// Error decoding
-    Decode(Base58DecodeError),
-    /// Error encoding
-    Encode(Base58EncodeError),
-}
-
-#[derive(Debug, Clone)]
-/// Errors when converting scalars
-pub enum ConversionError {
-    /// Error converting a byte slice into Scalar
-    WrongNumberOfBytes(usize),
-    /// Error converting a base58 string to bytes
-    Base58(Base58Error),
-}
+use crate::errors::{Base58Error, ConversionError};
 
 #[derive(Debug, Clone)]
 /// Errors in scalar operations

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -1,5 +1,5 @@
-use base58::{FromBase58, ToBase58};
 use bitvec::prelude::*;
+use bs58::{self, decode::Error as DecodeError, encode::Error as EncodeError};
 use core::{
     cmp::{Eq, PartialEq},
     convert::{From, TryFrom},
@@ -19,13 +19,27 @@ use crate::bindings::secp256k1_scalar;
 
 use crate::point::Point;
 
+/// Re-export of crate `bs58`'s decode error
+pub type Base58DecodeError = DecodeError;
+/// Re-export of crate `bs58`'s encode error
+pub type Base58EncodeError = EncodeError;
+
+#[derive(Debug, Clone)]
+/// Base58-related errors
+pub enum Base58Error {
+    /// Error decoding
+    Decode(Base58DecodeError),
+    /// Error encoding
+    Encode(Base58EncodeError),
+}
+
 #[derive(Debug, Clone)]
 /// Errors when converting scalars
 pub enum ConversionError {
     /// Error converting a byte slice into Scalar
     WrongNumberOfBytes(usize),
     /// Error converting a base58 string to bytes
-    Base58(String),
+    Base58(Base58Error),
 }
 
 #[derive(Debug, Clone)]
@@ -189,7 +203,7 @@ impl Default for Scalar {
 
 impl Display for Scalar {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}", self.to_bytes().to_base58())
+        write!(f, "{}", bs58::encode(self.to_bytes()).into_string())
     }
 }
 
@@ -249,19 +263,18 @@ impl TryFrom<&[u8]> for Scalar {
 impl TryFrom<&str> for Scalar {
     type Error = Error;
     fn try_from(s: &str) -> Result<Self, Error> {
-        match s.from_base58() {
+        match bs58::decode(s).into_vec() {
             Ok(bytes) => Scalar::try_from(&bytes[..]),
-            Err(e) => Err(Error::Conversion(ConversionError::Base58(format!(
-                "{:?}",
-                e
-            )))),
+            Err(e) => Err(Error::Conversion(ConversionError::Base58(
+                Base58Error::Decode(e),
+            ))),
         }
     }
 }
 
 impl From<Scalar> for String {
     fn from(s: Scalar) -> String {
-        s.to_bytes().to_base58()
+        bs58::encode(s.to_bytes()).into_string()
     }
 }
 

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -6,7 +6,7 @@ use syn::{ForeignItem, Ident, Item};
 fn main() {
     const USER: &str = "bitcoin-core";
     const REPO_NAME: &str = "secp256k1";
-    const COMMIT_SHA: &str = "c55290c0ae1031dcb8d8fed4fe3d6ab3f22c0511";
+    const COMMIT_SHA: &str = "2bca0a5cbf756dd4ff1f0bda4585a7d3c64e1480";
 
     let url = &format!("https://github.com/{USER}/{REPO_NAME}/archive/{COMMIT_SHA}.zip");
 

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -6,7 +6,7 @@ use syn::{ForeignItem, Ident, Item};
 fn main() {
     const USER: &str = "bitcoin-core";
     const REPO_NAME: &str = "secp256k1";
-    const COMMIT_SHA: &str = "2bca0a5cbf756dd4ff1f0bda4585a7d3c64e1480";
+    const COMMIT_SHA: &str = "491b4cd29d52048321e3c72f7585ce59154c2072";
 
     let url = &format!("https://github.com/{USER}/{REPO_NAME}/archive/{COMMIT_SHA}.zip");
 

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -6,7 +6,7 @@ use syn::{ForeignItem, Ident, Item};
 fn main() {
     const USER: &str = "bitcoin-core";
     const REPO_NAME: &str = "secp256k1";
-    const COMMIT_SHA: &str = "491b4cd29d52048321e3c72f7585ce59154c2072";
+    const COMMIT_SHA: &str = "c55290c0ae1031dcb8d8fed4fe3d6ab3f22c0511";
 
     let url = &format!("https://github.com/{USER}/{REPO_NAME}/archive/{COMMIT_SHA}.zip");
 


### PR DESCRIPTION
Part of the work required for https://github.com/Trust-Machines/core-eng/issues/320.

Swaps out crate `base58` for `bs58`.

Minor version bump despite some error-related `pub` types having changed, would another type of version bump be more appropriate?
