### PR TITLE
Use left shift to avoid unstable ilog

### DIFF
--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -41,6 +41,10 @@ criterion = "0.4.0"
 name = "point_bench"
 harness = false
 
+[[bench]]
+name = "scalar_bench"
+harness = false
+
 [lib]
 path = "src/lib.rs"    # The source file of the target.
 crate-type = ["lib"]   # The crate types to generate.

--- a/p256k1/benches/scalar_bench.rs
+++ b/p256k1/benches/scalar_bench.rs
@@ -1,0 +1,33 @@
+use num_traits::identities::One;
+use p256k1::scalar::Scalar;
+use rand_core::OsRng;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[allow(non_snake_case)]
+pub fn bench_pow(c: &mut Criterion) {
+    let mut rng = OsRng::default();
+    let n = 64usize;
+    let k = 1024u32;
+
+    let scalars: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
+
+    c.bench_function("scalar iterative pow", |b| {
+        b.iter(|| {
+            for i in &scalars {
+                (0..k).fold(Scalar::one(), |s, _| s * i);
+            }
+        })
+    });
+
+    c.bench_function("scalar square and multiply pow", |b| {
+        b.iter(|| {
+            for i in &scalars {
+                let _ = i ^ k;
+            }
+        })
+    });
+}
+
+criterion_group!(benches, bench_pow);
+criterion_main!(benches);

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -120,8 +120,7 @@ impl Scalar {
             return ret;
         }
 
-        let log = n.ilog2() + 1;
-        let mut i: u32 = 0;
+        let mut i: usize = 1;
         for byte in n.to_le_bytes() {
             let bits = byte.view_bits::<Lsb0>();
             for bit in bits {
@@ -129,9 +128,9 @@ impl Scalar {
                     ret *= square;
                 }
                 if {
-                    i += 1;
+                    i <<= 1;
                     i
-                } > log
+                } > n
                 {
                     return ret;
                 }
@@ -151,8 +150,7 @@ impl Scalar {
             return ret;
         }
 
-        let log = n.ilog2() + 1;
-        let mut i: u32 = 0;
+        let mut i: u32 = 1;
         for byte in n.to_le_bytes() {
             let bits = byte.view_bits::<Lsb0>();
             for bit in bits {
@@ -160,9 +158,9 @@ impl Scalar {
                     ret *= square;
                 }
                 if {
-                    i += 1;
+                    i <<= 1;
                     i
-                } > log
+                } > n
                 {
                     return ret;
                 }

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -112,60 +112,32 @@ impl Scalar {
     }
 
     /// Fast exponentiation using the square and multiply algorithm
-    pub fn square_and_multiply_usize(x: &Scalar, n: usize) -> Scalar {
+    pub fn square_and_multiply_usize(x: &Scalar, mut n: usize) -> Scalar {
         let mut ret = Scalar::one();
         let mut square = *x;
 
-        if n == 0 {
-            return ret;
-        }
-
-        let mut i: usize = 1;
-        for byte in n.to_le_bytes() {
-            let bits = byte.view_bits::<Lsb0>();
-            for bit in bits {
-                if *bit {
-                    ret *= square;
-                }
-                if {
-                    i <<= 1;
-                    i
-                } > n
-                {
-                    return ret;
-                }
-                square *= square;
+        while n != 0 {
+            if n & 1 != 0 {
+                ret *= square;
             }
+            square *= square;
+            n >>= 1;
         }
 
         ret
     }
 
     /// Fast exponentiation using the square and multiply algorithm
-    pub fn square_and_multiply_u32(x: &Scalar, n: u32) -> Scalar {
+    pub fn square_and_multiply_u32(x: &Scalar, mut n: u32) -> Scalar {
         let mut ret = Scalar::one();
         let mut square = *x;
 
-        if n == 0 {
-            return ret;
-        }
-
-        let mut i: u32 = 1;
-        for byte in n.to_le_bytes() {
-            let bits = byte.view_bits::<Lsb0>();
-            for bit in bits {
-                if *bit {
-                    ret *= square;
-                }
-                if {
-                    i <<= 1;
-                    i
-                } > n
-                {
-                    return ret;
-                }
-                square *= square;
+        while n != 0 {
+            if n & 1 != 0 {
+                ret *= square;
             }
+            square *= square;
+            n >>= 1;
         }
 
         ret


### PR DESCRIPTION
Apparently `u32::ilog` is an unstable Rust feature.  We can get the same result via a series of left shift operations, which should even be marginally faster.