### PR TITLE
debug should base58 the data so the logs aren't useless

### DIFF
--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256k1"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/p256k1/src/ecdsa.rs
+++ b/p256k1/src/ecdsa.rs
@@ -84,7 +84,7 @@ impl PublicKey {
 impl Debug for PublicKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.debug_struct("PublicKey")
-            .field("data", &self.key.data)
+            .field("data", &bs58::encode(self.key.data).into_string())
             .finish()
     }
 }


### PR DESCRIPTION
Previously `Display` and `Debug` were implemented for `ecdsa::PublicKey`.  But the resulting debug logs were unreadable due to the verbosity of the data buffers.  

This PR changes the `Display` formatting to `base58` the data buffers to help readability.