### PR TITLE
Add a MultiMult trait and a Point fn which uses it for the multimult operation

### DIFF
--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256k1"
-version = "5.2.2"
+version = "5.3.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/p256k1/src/lib.rs
+++ b/p256k1/src/lib.rs
@@ -32,4 +32,7 @@ pub mod scalar;
 /// Field elements arithmetic
 pub mod field;
 
+/// Traits
+pub mod traits;
+
 mod group;

--- a/p256k1/src/point.rs
+++ b/p256k1/src/point.rs
@@ -214,10 +214,7 @@ impl Point {
 
         unsafe {
             // empirically, number of elements * 512 is an ideal scratch space size
-            let scratch_size = match mm.get_scratch_size() {
-                Some(n) => n,
-                None => 1024 * 1024,
-            };
+            let scratch_size = mm.get_scratch_size().unwrap_or(1024 * 1024);
             let scratch = secp256k1_scratch_space_create(ctx.context, scratch_size);
             let i = secp256k1_ecmult_multi_var(
                 &multi_error_callback,

--- a/p256k1/src/traits.rs
+++ b/p256k1/src/traits.rs
@@ -1,0 +1,18 @@
+use crate::{point::Point, scalar::Scalar};
+
+/// A trait which allows wrapping up types to be used in multimult without excessive copying
+pub trait MultiMult {
+    /// return the Scalar at index i
+    fn get_scalar(&self, i: usize) -> &Scalar;
+
+    /// return the Point at index i
+    fn get_point(&self, i: usize) -> &Point;
+
+    /// return the number of scalars and points to multimult
+    fn get_size(&self) -> usize;
+
+    /// return an optimum scratch size, or None if there is none
+    fn get_scratch_size(&self) -> Option<usize> {
+        Some(self.get_size() * 512)
+    }
+}


### PR DESCRIPTION
This PR adds a `trait` `MultiMult`  and a `Point::multimult_trait` `fn` which uses it for `multimult` ops.  The existing `ScalarsPoints` object now implements the `trait`, and the existing `Point::multimult` `fn` now just makes a `ScalarsPoints` object and passes it to `multimult_trait`.   This resolves #69 

The trait also defines a `fn get_scratch_size` with a default implementation of `get_size() * 512`, which was empirically determined to be an optimal scratch size.  This resolves #17 
