### PR TITLE
Add custom serde for all structs

### DIFF
--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256k1"
-version = "5.5.0"
+version = "6.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -40,6 +40,7 @@ syn = { version = "2.0.10", features = ["full"] }
 [dev-dependencies]
 libc = "0.2"
 criterion = "0.4.0"
+serde_json = "1.0"
 
 [[bench]]
 name = "point_bench"

--- a/p256k1/src/ecdsa.rs
+++ b/p256k1/src/ecdsa.rs
@@ -1,13 +1,17 @@
+use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use std::array::TryFromSliceError;
 
 use crate::_rename::{
     secp256k1_ecdsa_sign, secp256k1_ecdsa_signature_parse_compact,
     secp256k1_ecdsa_signature_serialize_compact, secp256k1_ecdsa_verify,
 };
-use crate::bindings::secp256k1_ecdsa_signature;
-use crate::context::Context;
-use crate::errors::ConversionError;
-use crate::scalar::Scalar;
+use crate::{
+    bindings::secp256k1_ecdsa_signature, context::Context, errors::ConversionError, scalar::Scalar,
+};
 
 pub use crate::keys::{Error as KeyError, PublicKey};
 
@@ -21,7 +25,7 @@ pub enum Error {
     /// Error converting a scalar
     Conversion(ConversionError),
 }
-impl std::fmt::Display for Error {
+impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
@@ -90,6 +94,57 @@ impl Signature {
             );
         }
         bytes
+    }
+}
+
+impl Serialize for Signature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.to_bytes())
+    }
+}
+
+struct SignatureVisitor;
+
+impl<'de> Visitor<'de> for SignatureVisitor {
+    type Value = Signature;
+
+    fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+        formatter.write_str("an array of bytes which represents two scalars on the secp256k1 curve")
+    }
+
+    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        match Signature::try_from(value) {
+            Ok(s) => Ok(s),
+            Err(e) => Err(E::custom(format!("{:?}", e))),
+        }
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let mut v = Vec::new();
+
+        while let Ok(Some(x)) = seq.next_element() {
+            v.push(x);
+        }
+
+        self.visit_bytes(&v)
+    }
+}
+
+impl<'de> Deserialize<'de> for Signature {
+    fn deserialize<D>(deserializer: D) -> Result<Signature, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(SignatureVisitor)
     }
 }
 
@@ -215,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    fn signature_serde() {
+    fn manual_serde() {
         // Generate random data bytes
         let mut rng = OsRng::default();
         let mut bytes = [0u8; 64];
@@ -225,5 +280,22 @@ mod tests {
         let sig = Signature::try_from(bytes).unwrap();
         assert_ne!(sig.signature.data, bytes);
         assert_eq!(sig.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn custom_serde() {
+        let mut rng = OsRng::default();
+        let mut hash = [0u8; 32];
+        rng.fill_bytes(&mut hash);
+        let private_key = Scalar::random(&mut rng);
+        let public_key = PublicKey::new(&private_key).expect("failed to create public key");
+        let sig = Signature::new(&hash, &private_key).expect("failed to create sig");
+
+        assert!(sig.verify(&hash, &public_key));
+
+        let ssig = serde_json::to_string(&sig).expect("failed to serialize");
+        let dsig: Signature = serde_json::from_str(&ssig).expect("failed to deserialize");
+
+        assert!(dsig.verify(&hash, &public_key));
     }
 }

--- a/p256k1/src/ecdsa.rs
+++ b/p256k1/src/ecdsa.rs
@@ -99,6 +99,12 @@ impl Signature {
     }
 }
 
+impl Display for Signature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", bs58::encode(self.to_bytes()).into_string())
+    }
+}
+
 impl Serialize for Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/p256k1/src/ecdsa.rs
+++ b/p256k1/src/ecdsa.rs
@@ -26,7 +26,7 @@ pub enum Error {
     Conversion(ConversionError),
 }
 impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{:?}", self)
     }
 }

--- a/p256k1/src/ecdsa.rs
+++ b/p256k1/src/ecdsa.rs
@@ -40,6 +40,7 @@ impl From<TryFromSliceError> for Error {
 /**
 Signature is a wrapper around libsecp256k1's secp256k1_ecdsa_signature struct.
 */
+#[derive(Debug, Clone)]
 pub struct Signature {
     /// The wrapped libsecp256k1 signature
     pub signature: secp256k1_ecdsa_signature,

--- a/p256k1/src/field.rs
+++ b/p256k1/src/field.rs
@@ -9,6 +9,10 @@ use core::{
 };
 use num_traits::{One, Zero};
 use rand_core::{CryptoRng, RngCore};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 use crate::_rename::{
     secp256k1_fe_add, secp256k1_fe_cmp_var, secp256k1_fe_get_b32, secp256k1_fe_inv,
@@ -34,7 +38,7 @@ pub enum Error {
     Conversion(ConversionError),
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Copy, Clone, Debug)]
 /**
 Element is a wrapper around libsecp256k1's internal secp256k1_fe struct.  It provides a field element, which is like a scalar but not necessarily reduced modulo the group order
  */
@@ -159,6 +163,60 @@ impl PartialEq for Element {
 }
 
 impl Eq for Element {}
+
+impl Serialize for Element {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.to_bytes())
+    }
+}
+
+struct ElementVisitor;
+
+impl<'de> Visitor<'de> for ElementVisitor {
+    type Value = Element;
+
+    fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+        formatter.write_str("an array of bytes which represents a point on the secp256k1 curve")
+    }
+
+    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        match Self::Value::try_from(value) {
+            Ok(s) => Ok(s),
+            Err(e) => Err(E::custom(format!("{:?}", e))),
+        }
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let mut v = Vec::new();
+
+        loop {
+            match seq.next_element() {
+                Ok(Some(x)) => v.push(x),
+                _ => break,
+            }
+        }
+
+        self.visit_bytes(&v)
+    }
+}
+
+impl<'de> Deserialize<'de> for Element {
+    fn deserialize<D>(deserializer: D) -> Result<Element, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(ElementVisitor)
+    }
+}
 
 impl Hash for Element {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -607,5 +665,15 @@ mod tests {
         assert_eq!(a, b);
         assert_eq!(a, c);
         assert_eq!(s, t);
+    }
+
+    #[test]
+    fn serde() {
+        let mut rng = OsRng::default();
+        let x = Element::random(&mut rng);
+        let s = serde_json::to_string(&x).expect("failed to serialize");
+        let y = serde_json::from_str(&s).expect("failed to deserialize");
+
+        assert_eq!(x, y);
     }
 }

--- a/p256k1/src/field.rs
+++ b/p256k1/src/field.rs
@@ -198,11 +198,8 @@ impl<'de> Visitor<'de> for ElementVisitor {
     {
         let mut v = Vec::new();
 
-        loop {
-            match seq.next_element() {
-                Ok(Some(x)) => v.push(x),
-                _ => break,
-            }
+        while let Ok(Some(x)) = seq.next_element() {
+            v.push(x);
         }
 
         self.visit_bytes(&v)

--- a/p256k1/src/field.rs
+++ b/p256k1/src/field.rs
@@ -38,6 +38,12 @@ pub enum Error {
     Conversion(ConversionError),
 }
 
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{:?}", self)
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 /**
 Element is a wrapper around libsecp256k1's internal secp256k1_fe struct.  It provides a field element, which is like a scalar but not necessarily reduced modulo the group order

--- a/p256k1/src/field.rs
+++ b/p256k1/src/field.rs
@@ -179,7 +179,8 @@ impl<'de> Visitor<'de> for ElementVisitor {
     type Value = Element;
 
     fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
-        formatter.write_str("an array of bytes which represents a point on the secp256k1 curve")
+        formatter
+            .write_str("an array of bytes which represents field element for the secp256k1 curve")
     }
 
     fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
@@ -665,7 +666,7 @@ mod tests {
     }
 
     #[test]
-    fn serde() {
+    fn custom_serde() {
         let mut rng = OsRng::default();
         let x = Element::random(&mut rng);
         let s = serde_json::to_string(&x).expect("failed to serialize");

--- a/p256k1/src/keys.rs
+++ b/p256k1/src/keys.rs
@@ -33,8 +33,8 @@ pub enum Error {
     /// Error converting a scalar
     Conversion(ConversionError),
 }
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{:?}", self)
     }
 }

--- a/p256k1/src/point.rs
+++ b/p256k1/src/point.rs
@@ -79,6 +79,12 @@ pub enum Error {
     LiftFailed,
 }
 
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{:?}", self)
+    }
+}
+
 #[derive(Copy, Clone)]
 /**
 Point is a wrapper around libsecp256k1's internal secp256k1_gej struct.  It provides a point on the secp256k1 curve in Jacobian coordinates.  This allows for extremely fast curve point operations, and avoids expensive conversions from byte buffers.

--- a/p256k1/src/point.rs
+++ b/p256k1/src/point.rs
@@ -378,11 +378,8 @@ impl<'de> Visitor<'de> for PointVisitor {
     {
         let mut v = Vec::new();
 
-        loop {
-            match seq.next_element() {
-                Ok(Some(x)) => v.push(x),
-                _ => break,
-            }
+        while let Ok(Some(x)) = seq.next_element() {
+            v.push(x);
         }
 
         self.visit_bytes(&v)

--- a/p256k1/src/point.rs
+++ b/p256k1/src/point.rs
@@ -17,6 +17,12 @@ use serde::{
 };
 use std::os::raw::c_void;
 
+use crate::_rename::{
+    secp256k1_ecmult, secp256k1_ecmult_multi_var, secp256k1_fe_get_b32, secp256k1_fe_is_odd,
+    secp256k1_fe_normalize_var, secp256k1_fe_set_b32, secp256k1_ge_set_xo_var,
+    secp256k1_gej_add_var, secp256k1_gej_neg, secp256k1_gej_set_ge, secp256k1_scratch_space_create,
+    secp256k1_scratch_space_destroy,
+};
 use crate::{
     bindings::{
         secp256k1_callback, secp256k1_ecmult_multi_callback, secp256k1_fe, secp256k1_ge,
@@ -28,13 +34,6 @@ use crate::{
     group::secp256k1_ge_set_gej,
     scalar::Scalar,
     traits::MultiMult,
-};
-
-use crate::_rename::{
-    secp256k1_ecmult, secp256k1_ecmult_multi_var, secp256k1_fe_get_b32, secp256k1_fe_is_odd,
-    secp256k1_fe_normalize_var, secp256k1_fe_set_b32, secp256k1_ge_set_xo_var,
-    secp256k1_gej_add_var, secp256k1_gej_neg, secp256k1_gej_set_ge, secp256k1_scratch_space_create,
-    secp256k1_scratch_space_destroy,
 };
 
 /// The secp256k1 base point
@@ -887,7 +886,7 @@ mod tests {
     }
 
     #[test]
-    fn serde() {
+    fn custom_serde() {
         let mut rng = OsRng::default();
         let p = Point::from(Scalar::random(&mut rng));
         let s = serde_json::to_string(&p).expect("failed to serialize");

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -188,7 +188,7 @@ impl<'de> Visitor<'de> for ScalarVisitor {
     type Value = Scalar;
 
     fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
-        formatter.write_str("an array of bytes which represents a point on the secp256k1 curve")
+        formatter.write_str("an array of bytes which represents a scalar for the secp256k1 curve")
     }
 
     fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
@@ -827,7 +827,7 @@ mod tests {
     }
 
     #[test]
-    fn serde() {
+    fn custom_serde() {
         let mut rng = OsRng::default();
         let x = Scalar::random(&mut rng);
         let s = serde_json::to_string(&x).expect("failed to serialize");

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -207,11 +207,8 @@ impl<'de> Visitor<'de> for ScalarVisitor {
     {
         let mut v = Vec::new();
 
-        loop {
-            match seq.next_element() {
-                Ok(Some(x)) => v.push(x),
-                _ => break,
-            }
+        while let Ok(Some(x)) = seq.next_element() {
+            v.push(x);
         }
 
         self.visit_bytes(&v)

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -31,8 +31,8 @@ pub enum Error {
     /// Error converting a scalar
     Conversion(ConversionError),
 }
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{:?}", self)
     }
 }

--- a/p256k1/src/schnorr.rs
+++ b/p256k1/src/schnorr.rs
@@ -26,7 +26,7 @@ pub enum Error {
     Conversion(ConversionError),
 }
 impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{:?}", self)
     }
 }

--- a/p256k1/src/schnorr.rs
+++ b/p256k1/src/schnorr.rs
@@ -97,6 +97,12 @@ impl Signature {
     }
 }
 
+impl Display for Signature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", bs58::encode(self.to_bytes()).into_string())
+    }
+}
+
 impl Serialize for Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
`libsecp256k1` uses platform dependent representations of data internally, to speed calculations.  This means that you cannot in general serialize the object data directly, but rather must use explicit semantics to convert to and from stable platform independent byte representations.

Implement custom `serde` seralizers and deserializers for all structs to prevent accidental mis-serializations.  Clean up imports, and make sure all structs `impl` `Debug` and `Clone`, and where appropriate `Display` and `Copy`.