### PR TITLE
Flatten `Base58Error` to allow trivial serialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop -A clippy::suspicious-arithmetic-impl -A clippy::suspicious-op-assign-impl -A unused_imports
+          args: -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop -A clippy::suspicious-arithmetic-impl -A clippy::suspicious-op-assign-impl
 
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop -A clippy::suspicious-arithmetic-impl -A clippy::suspicious-op-assign-impl
+          args: -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop -A clippy::suspicious-arithmetic-impl -A clippy::suspicious-op-assign-impl -A unused_imports
 
   package:
     runs-on: ubuntu-latest

--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256k1"
-version = "6.0.0"
+version = "7.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/p256k1/src/errors.rs
+++ b/p256k1/src/errors.rs
@@ -1,20 +1,31 @@
 use bs58::{decode::Error as DecodeError, encode::Error as EncodeError};
+use core::{
+    cmp::PartialEq,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+};
+use serde::{Deserialize, Serialize};
 
 /// Re-export of crate `bs58`'s decode error
 pub type Base58DecodeError = DecodeError;
 /// Re-export of crate `bs58`'s encode error
 pub type Base58EncodeError = EncodeError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// Base58-related errors
 pub enum Base58Error {
     /// Error decoding
-    Decode(Base58DecodeError),
+    Decode,
     /// Error encoding
-    Encode(Base58EncodeError),
+    Encode,
 }
 
-#[derive(Debug, Clone)]
+impl Display for Base58Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// Errors when performing conversion operations
 pub enum ConversionError {
     /// Error decompressing a point into a field element

--- a/p256k1/src/errors.rs
+++ b/p256k1/src/errors.rs
@@ -1,14 +1,8 @@
-use bs58::{decode::Error as DecodeError, encode::Error as EncodeError};
 use core::{
     cmp::PartialEq,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
 };
 use serde::{Deserialize, Serialize};
-
-/// Re-export of crate `bs58`'s decode error
-pub type Base58DecodeError = DecodeError;
-/// Re-export of crate `bs58`'s encode error
-pub type Base58EncodeError = EncodeError;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// Base58-related errors

--- a/p256k1/src/field.rs
+++ b/p256k1/src/field.rs
@@ -278,8 +278,8 @@ impl TryFrom<&str> for Element {
     fn try_from(s: &str) -> Result<Self, Error> {
         match bs58::decode(s).into_vec() {
             Ok(bytes) => Element::try_from(&bytes[..]),
-            Err(e) => Err(Error::Conversion(ConversionError::Base58(
-                Base58Error::Decode(e),
+            Err(_e) => Err(Error::Conversion(ConversionError::Base58(
+                Base58Error::Decode, //(e),
             ))),
         }
     }

--- a/p256k1/src/keys.rs
+++ b/p256k1/src/keys.rs
@@ -161,8 +161,8 @@ impl TryFrom<&str> for PublicKey {
     fn try_from(s: &str) -> Result<Self, self::Error> {
         match bs58::decode(s).into_vec() {
             Ok(bytes) => PublicKey::try_from(&bytes[..]),
-            Err(e) => Err(Error::Conversion(ConversionError::Base58(
-                Base58Error::Decode(e),
+            Err(_e) => Err(Error::Conversion(ConversionError::Base58(
+                Base58Error::Decode, //(e),
             ))),
         }
     }
@@ -292,8 +292,8 @@ impl TryFrom<&str> for XOnlyPublicKey {
     fn try_from(s: &str) -> Result<Self, self::Error> {
         match bs58::decode(s).into_vec() {
             Ok(bytes) => XOnlyPublicKey::try_from(&bytes[..]),
-            Err(e) => Err(Error::Conversion(ConversionError::Base58(
-                Base58Error::Decode(e),
+            Err(_e) => Err(Error::Conversion(ConversionError::Base58(
+                Base58Error::Decode, //(e),
             ))),
         }
     }

--- a/p256k1/src/lib.rs
+++ b/p256k1/src/lib.rs
@@ -17,6 +17,7 @@ mod bindings {
 #[cfg(not(feature = "with_bindgen"))]
 mod bindings;
 
+#[allow(unused_imports)]
 mod _rename;
 
 /// secp256k1 context operations

--- a/p256k1/src/point.rs
+++ b/p256k1/src/point.rs
@@ -68,7 +68,7 @@ pub const N: [u8; 32] = [
     0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x41,
 ];
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// Errors in point operations
 pub enum Error {
     /// Error doing multi-exponentiation
@@ -711,8 +711,8 @@ impl TryFrom<&str> for Compressed {
     fn try_from(s: &str) -> Result<Self, Error> {
         match bs58::decode(s).into_vec() {
             Ok(bytes) => Compressed::try_from(&bytes[..]),
-            Err(e) => Err(Error::Conversion(ConversionError::Base58(
-                Base58Error::Decode(e),
+            Err(_e) => Err(Error::Conversion(ConversionError::Base58(
+                Base58Error::Decode, //(e),
             ))),
         }
     }

--- a/p256k1/src/point.rs
+++ b/p256k1/src/point.rs
@@ -482,9 +482,7 @@ impl TryFrom<&Compressed> for Point {
             let ry = secp256k1_ge_set_xo_var(
                 &mut y,
                 &x,
-                (c.data[0] as u32 == SECP256K1_TAG_PUBKEY_ODD)
-                    .try_into()
-                    .unwrap(),
+                (c.data[0] as u32 == SECP256K1_TAG_PUBKEY_ODD).into(),
             );
             if ry == 0 {
                 return Err(Error::Conversion(ConversionError::BadGroupElement));

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -274,8 +274,8 @@ impl TryFrom<&str> for Scalar {
     fn try_from(s: &str) -> Result<Self, Error> {
         match bs58::decode(s).into_vec() {
             Ok(bytes) => Scalar::try_from(&bytes[..]),
-            Err(e) => Err(Error::Conversion(ConversionError::Base58(
-                Base58Error::Decode(e),
+            Err(_e) => Err(Error::Conversion(ConversionError::Base58(
+                Base58Error::Decode, //(e),
             ))),
         }
     }


### PR DESCRIPTION
When doing `bs58` conversions, there are a variety of possible errors which can be returned.  Unfortunately, these errors do not `impl` `Serialize` or `Deserialize`, so we can't trivially wrap them.  And we frankly don't care; it's enough to know that an error was caused by `bs58` serialization.

So to allow serializing errors, do not wrap the `bs58` error types in the `errors::Base58Error` variants.
