### PR TITLE
feat: Implement missing common traits for public types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["p256k1", "update"]
+resolver = "2"

--- a/p256k1/src/errors.rs
+++ b/p256k1/src/errors.rs
@@ -31,3 +31,12 @@ pub enum ConversionError {
     /// Error converting a base58-related value
     Base58(Base58Error),
 }
+
+impl Display for ConversionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Base58Error {}
+impl std::error::Error for ConversionError {}

--- a/p256k1/src/point.rs
+++ b/p256k1/src/point.rs
@@ -85,6 +85,8 @@ impl Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 #[derive(Copy, Clone)]
 /**
 Point is a wrapper around libsecp256k1's internal secp256k1_gej struct.  It provides a point on the secp256k1 curve in Jacobian coordinates.  This allows for extremely fast curve point operations, and avoids expensive conversions from byte buffers.

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -37,6 +37,8 @@ impl Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 #[derive(Copy, Clone, Debug)]
 /**
 Scalar is a wrapper around libsecp256k1's internal secp256k1_scalar struct.  It provides a scalar modulo the group order.  Storing scalars in this format avoids unnecessary conversions from byte bffers, which provides a significant performance enhancement.


### PR DESCRIPTION
This PR implements common traits for public types following the recommendations in https://rust-lang.github.io/api-guidelines/

Note that many of the underlying operations are quite inefficient. The alternative would be to have varying behavior on different platforms, which wouldn't be an issue for `PartialEq`, `Eq` and `Hash`, but for `PartialOrd` and `Ord` this could lead to bugs in client code expecting ordering to be consistent.

I chose to be slow and consistent for the trait implementations in line with how it's done in `secp256k1_sys`. Interestingly, that crate provides helper functions like [`PublicKey::cmp_fast_unstable`](https://docs.rs/secp256k1-sys/0.9.2/secp256k1_sys/struct.PublicKey.html#method.cmp_fast_unstable) for the more performant implementations - which is something we also could do if the need arises.