### PR TITLE
Increment minor semver for release

### DIFF
--- a/p256k1/Cargo.toml
+++ b/p256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p256k1"
-version = "7.0.0"
+version = "7.1.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
A recent PR implemented a number of convenience traits relating to ordering and equality, but did not increment the minor semver.  This PR does so to allow us to publish a new crate.