### PR TITLE
Mark secp256k1 fields as pub(crate) not pub

### DIFF
--- a/p256k1/src/context.rs
+++ b/p256k1/src/context.rs
@@ -7,7 +7,7 @@ Context is a wrapper around libsecp256k1's internal secp256k1_context struct.
 */
 pub struct Context {
     /// The wrapped libsecp256k1 context
-    pub context: *mut secp256k1_context,
+    pub(crate) context: *mut secp256k1_context,
 }
 
 impl Default for Context {

--- a/p256k1/src/ecdsa.rs
+++ b/p256k1/src/ecdsa.rs
@@ -46,7 +46,7 @@ Signature is a wrapper around libsecp256k1's secp256k1_ecdsa_signature struct.
 #[derive(Debug, Clone)]
 pub struct Signature {
     /// The wrapped libsecp256k1 signature
-    pub signature: secp256k1_ecdsa_signature,
+    pub(crate) signature: secp256k1_ecdsa_signature,
 }
 
 impl Signature {

--- a/p256k1/src/field.rs
+++ b/p256k1/src/field.rs
@@ -53,7 +53,7 @@ Element is a wrapper around libsecp256k1's internal secp256k1_fe struct.  It pro
  */
 pub struct Element {
     /// The wrapped libsecp256k1 fe
-    pub fe: secp256k1_fe,
+    pub(crate) fe: secp256k1_fe,
 }
 
 impl Element {

--- a/p256k1/src/keys.rs
+++ b/p256k1/src/keys.rs
@@ -54,7 +54,7 @@ PublicKey is a wrapper around libsecp256k1's secp256k1_pubkey struct.
 #[derive(Clone, Copy)]
 pub struct PublicKey {
     /// The wrapped secp256k1_pubkey public key
-    pub key: secp256k1_pubkey,
+    pub(crate) key: secp256k1_pubkey,
 }
 
 impl PublicKey {
@@ -233,7 +233,7 @@ XOnlyPublicKey is a wrapper around libsecp256k1's secp256k1_xonly_pubkey struct.
 #[derive(Clone, Copy)]
 pub struct XOnlyPublicKey {
     /// The wrapped secp256k1_xonly_pubkey public key
-    pub key: secp256k1_xonly_pubkey,
+    pub(crate) key: secp256k1_xonly_pubkey,
     /// The parity bit of this key
     pub parity: i32,
 }
@@ -417,7 +417,7 @@ KeyPair is a wrapper around libsecp256k1's secp256k1_keypair struct.
 #[derive(Clone, Copy)]
 pub struct KeyPair {
     /// The wrapped secp256k1_keypair
-    pub key: secp256k1_keypair,
+    pub(crate) key: secp256k1_keypair,
 }
 
 impl KeyPair {

--- a/p256k1/src/point.rs
+++ b/p256k1/src/point.rs
@@ -93,7 +93,7 @@ Point is a wrapper around libsecp256k1's internal secp256k1_gej struct.  It prov
  */
 pub struct Point {
     /// The wrapped libsecp256k1 point
-    pub gej: secp256k1_gej,
+    pub(crate) gej: secp256k1_gej,
 }
 
 #[no_mangle]

--- a/p256k1/src/scalar.rs
+++ b/p256k1/src/scalar.rs
@@ -46,7 +46,7 @@ Scalar is a wrapper around libsecp256k1's internal secp256k1_scalar struct.  It 
  */
 pub struct Scalar {
     /// The wrapped libsecp256k1 scalar
-    pub scalar: secp256k1_scalar,
+    pub(crate) scalar: secp256k1_scalar,
 }
 
 impl Scalar {


### PR DESCRIPTION
Currently the wrapped C objects are marked as `pub`, for two reasons.  First, some of the modules currently need to interact with the C objects of other modules, in particular `Scalar` and `Point` for scalar multiplication.  Second, it is always possible that users of the library will need to descend to the C layer for unexpected reasons.

However, leaving these objects exposed is a violation of encapsulation.  We recently discovered a class of vulnerabilities related to invalid curve points, which is being partially addressed by #90 .  But at this point the flexibility of leaving the fields `pub` seems like a poor tradeoff.